### PR TITLE
"Texture Input Mode" pin is now set to "Inherit" for some modules

### DIFF
--- a/nodes/modules/ChangeFormat (DX11.Texture 2d).v4p
+++ b/nodes/modules/ChangeFormat (DX11.Texture 2d).v4p
@@ -1,17 +1,17 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\ChangeFormat (DX11.Texture 2d).v4p" systemname="ChangeFormat (DX11.Texture 2d)" filename="X:\ChangeFormat (DX11.Texture 2d).v4p" scrollx="0" scrolly="0">
-   <BOUNDS type="Window" left="7110" top="5100" width="9000" height="6000">
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\ChangeFormat (DX11.Texture 2d).v4p" systemname="ChangeFormat (DX11.Texture 2d)" filename="X:\ChangeFormat (DX11.Texture 2d).v4p">
+   <BOUNDS type="Window" left="7110" top="5100" width="9000" height="6390">
    </BOUNDS>
    <NODE systemname="Renderer (DX11 TempTarget)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11 TempTarget)" componentmode="Hidden" id="1">
-   <BOUNDS type="Node" left="1485" top="3750" width="100" height="100">
+   <BOUNDS type="Node" left="1470" top="3285" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Layer" visible="1" slicecount="1" values="||">
+   <PIN pinname="Layer" visible="1">
    </PIN>
    <PIN pinname="Depth Buffer Mode" slicecount="1" values="None">
    </PIN>
    <PIN pinname="Depth Buffer Format" slicecount="1" values="D32_Float">
    </PIN>
-   <PIN pinname="Texture Input Mode" slicecount="1" values="InheritSize">
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    <PIN pinname="Buffers" visible="1">
    </PIN>
@@ -47,6 +47,8 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="4" srcpinname="Transform Out" dstnodeid="3" dstpinname="Transform">
+   </LINK>
+   <LINK srcnodeid="3" srcpinname="Layer" dstnodeid="1" dstpinname="Layer">
    </LINK>
    <NODE nodename="IOBox (Node)" componentmode="InABox" id="5" systemname="IOBox (Node)">
    <BOUNDS type="Box" left="240" top="690" width="795" height="240">
@@ -100,8 +102,6 @@
    <PIN pinname="Rows" slicecount="1" values="2">
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="|Texture ScaleXY|">
-   </PIN>
-   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
    </PIN>
    </NODE>
    <LINK srcnodeid="7" srcpinname="Y Output Value" dstnodeid="1" dstpinname="Texture ScaleXY">
@@ -199,146 +199,6 @@
    </PIN>
    </NODE>
    <LINK srcnodeid="15" srcpinname="Color Output" dstnodeid="3" dstpinname="Color">
-   </LINK>
-   <NODE systemname="Quad (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Quad (DX11.Layer)" componentmode="Hidden" id="16">
-   <BOUNDS type="Node" left="5505" top="4005" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Transform" visible="1">
-   </PIN>
-   <PIN pinname="Render State" visible="1">
-   </PIN>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Enabled" visible="1">
-   </PIN>
-   <PIN pinname="Color" visible="1">
-   </PIN>
-   </NODE>
-   <NODE systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" id="17">
-   <BOUNDS type="Node" left="5670" top="3600" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Transform Out" visible="1">
-   </PIN>
-   <PIN pinname="XYZ" slicecount="1" values="2">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="17" srcpinname="Transform Out" dstnodeid="16" dstpinname="Transform">
-   </LINK>
-   <NODE systemname="Blend (DX11.RenderState Advanced)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Blend (DX11.RenderState Advanced)" componentmode="Hidden" id="18">
-   <BOUNDS type="Node" left="5505" top="3210" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Render State" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Enabled" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Operation" slicecount="1" values="Add">
-   </PIN>
-   <PIN pinname="Alpha Operation" slicecount="1" values="Add">
-   </PIN>
-   <PIN pinname="Destination Blend" slicecount="1" values="One">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="18" srcpinname="Render State" dstnodeid="16" dstpinname="Render State">
-   </LINK>
-   <NODE systemname="Group (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Group (DX11.Layer)" componentmode="Hidden" id="19">
-   <BOUNDS type="Node" left="5160" top="4425" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Layer 2" visible="1">
-   </PIN>
-   <PIN pinname="Layer 1" visible="1">
-   </PIN>
-   <PIN pinname="Layer Out" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="16" srcpinname="Layer" dstnodeid="19" dstpinname="Layer 2">
-   </LINK>
-   <LINK srcnodeid="3" srcpinname="Layer" dstnodeid="19" dstpinname="Layer 1">
-   </LINK>
-   <LINK srcnodeid="19" srcpinname="Layer Out" dstnodeid="1" dstpinname="Layer">
-   </LINK>
-   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="20">
-   <BOUNDS type="Node" left="6675" top="1110" width="100" height="100">
-   </BOUNDS>
-   <BOUNDS type="Box" left="6675" top="1110" width="480" height="480">
-   </BOUNDS>
-   <PIN pinname="Value Type" slicecount="1" values="Boolean">
-   </PIN>
-   <PIN pinname="Behavior" slicecount="1" values="Toggle">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Alpha">
-   </PIN>
-   <PIN pinname="X Input Value" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Y Input Value" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Default" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Y Output Value" visible="1">
-   </PIN>
-   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
-   </PIN>
-   </NODE>
-   <NODE systemname="NOT (Boolean)" nodename="NOT (Boolean)" componentmode="Hidden" id="21">
-   <BOUNDS type="Node" left="6645" top="1695" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="20" srcpinname="Y Output Value" dstnodeid="21" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="21" srcpinname="Output" dstnodeid="16" dstpinname="Enabled">
-   </LINK>
-   <NODE systemname="RGB (Color Join)" nodename="RGB (Color Join)" componentmode="Hidden" id="22">
-   <BOUNDS type="Node" left="7230" top="3615" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Red" visible="1">
-   </PIN>
-   <PIN pinname="Green" visible="1">
-   </PIN>
-   <PIN pinname="Blue" visible="1">
-   </PIN>
-   <PIN pinname="Alpha" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="23" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7245" top="3315" width="795" height="240">
-   </BOUNDS>
-   <BOUNDS type="Node" left="7245" top="3315" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Y Output Value" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="23" srcpinname="Y Output Value" dstnodeid="22" dstpinname="Red">
-   </LINK>
-   <LINK srcnodeid="23" srcpinname="Y Output Value" dstnodeid="22" dstpinname="Green">
-   </LINK>
-   <LINK srcnodeid="23" srcpinname="Y Output Value" dstnodeid="22" dstpinname="Blue">
-   </LINK>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="24" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="7335" top="2970" width="795" height="240">
-   </BOUNDS>
-   <BOUNDS type="Node" left="7335" top="2970" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="24" srcpinname="Y Output Value" dstnodeid="22" dstpinname="Alpha">
-   </LINK>
-   <LINK srcnodeid="22" srcpinname="Output" dstnodeid="16" dstpinname="Color">
    </LINK>
    <PACK Name="addonpack" Version="33.7.0">
    </PACK>

--- a/nodes/modules/Crop/Crop (DX11.Texture 2d).v4p
+++ b/nodes/modules/Crop/Crop (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta32.1.dtd" >
-   <PATCH nodename="W:\Resize\Crop (DX11.Texture 2d).v4p" systemname="Crop (DX11.Texture 2d)" filename="X:\Crop (DX11.Texture 2d).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Crop\Crop (DX11.Texture 2d).v4p" systemname="Crop (DX11.Texture 2d)" filename="X:\Crop (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="11265" top="5295" width="7170" height="7695">
    </BOUNDS>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="8" systemname="IOBox (Enumerations)">
@@ -105,6 +105,8 @@
    </PIN>
    <PIN pinname="Layer" visible="1">
    </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
+   </PIN>
    </NODE>
    <LINK srcnodeid="8" srcpinname="Output Enum" dstnodeid="10" dstpinname="Target Format">
    </LINK>
@@ -158,7 +160,7 @@
    <PIN pinname="Output Node" visible="1">
    </PIN>
    </NODE>
-   <PACK Name="addonpack" Version="31.9.0">
+   <PACK Name="addonpack" Version="33.7.0">
    </PACK>
    <NODE systemname="Crop (DX11.Effect)" filename="Crop.fx" nodename="Crop (DX11.Effect)" componentmode="Hidden" id="27">
    <BOUNDS type="Node" left="3150" top="4035" width="100" height="100">
@@ -167,7 +169,7 @@
    </PIN>
    <PIN pinname="Geometry" visible="1">
    </PIN>
-   <PIN pinname="Texture" visible="1">
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Layer" visible="1">
    </PIN>

--- a/nodes/modules/Cubemap/CubeToPano (DX11.Texture 2d).v4p
+++ b/nodes/modules/Cubemap/CubeToPano (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.dtd" >
-   <PATCH nodename="X:\CubeMap\CubeToPano\CubeToPano (DX11.Texture 2d).v4p" systemname="CubeToPano (DX11.Texture 2d)" filename="X:\StarBackground\CubeToPano\CubeToPano (DX11.Texture 2d).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Cubemap\CubeToPano (DX11.Texture 2d).v4p" systemname="CubeToPano (DX11.Texture 2d)" filename="X:\StarBackground\CubeToPano\CubeToPano (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="6765" top="8490" width="9000" height="6000">
    </BOUNDS>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="0">
@@ -28,6 +28,8 @@
    <PIN pinname="Layer" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Buffers" visible="1">
+   </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    </NODE>
    <NODE systemname="CubeToPanoDX11 (DX11.Effect)" filename="CubeToPanoDX11.fx" nodename="CubeToPanoDX11 (DX11.Effect)" componentmode="Hidden" id="4">
@@ -162,4 +164,6 @@
    </NODE>
    <LINK srcnodeid="12" srcpinname="Y Output Value" dstnodeid="3" dstpinname="Texture SizeXY">
    </LINK>
+   <PACK Name="addonpack" Version="33.7.0">
+   </PACK>
    </PATCH>

--- a/nodes/modules/Cubemap/CubeToSphere (DX11.Texture 2d).v4p
+++ b/nodes/modules/Cubemap/CubeToSphere (DX11.Texture 2d).v4p
@@ -1,6 +1,6 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.2.dtd" >
-   <PATCH nodename="X:\Cubemap\CubeToSphere (DX11.Texture 2d).v4p" systemname="CubeToSphere (DX11.Texture 2d)" filename="X:\StarBackground\CubeToSphere\CubeToSphere (DX11.Texture 2d).v4p">
-   <BOUNDS type="Window" left="20220" top="7950" width="9000" height="5040">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Cubemap\CubeToSphere (DX11.Texture 2d).v4p" systemname="CubeToSphere (DX11.Texture 2d)" filename="X:\StarBackground\CubeToSphere\CubeToSphere (DX11.Texture 2d).v4p">
+   <BOUNDS type="Window" left="12435" top="8925" width="9000" height="5040">
    </BOUNDS>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="0">
    <BOUNDS type="Node" left="240" top="15" width="100" height="100">
@@ -28,6 +28,8 @@
    <PIN pinname="Layer" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Buffers" visible="1">
+   </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    </NODE>
    <NODE systemname="CubeToSphereDX11 (DX11.Effect)" filename="CubeToSphereDX11.fx" nodename="CubeToSphereDX11 (DX11.Effect)" componentmode="Hidden" id="4">
@@ -167,7 +169,7 @@
    </BOUNDS>
    <BOUNDS type="Node" left="5940" top="1545" width="0" height="0">
    </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" values="1.0">
+   <PIN pinname="Y Input Value" slicecount="1" values="1">
    </PIN>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -210,4 +212,6 @@
    </NODE>
    <LINK srcnodeid="15" srcpinname="Y Output Value" dstnodeid="4" dstpinname="ClipBorder">
    </LINK>
+   <PACK Name="addonpack" Version="33.7.0">
+   </PACK>
    </PATCH>

--- a/nodes/modules/Cubemap/PanoToSphere (DX11.Texture 2d).v4p
+++ b/nodes/modules/Cubemap/PanoToSphere (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.2.dtd" >
-   <PATCH nodename="X:\Cubemap\PanoToSphere (DX11.Texture 2d).v4p" systemname="PanoToSphere (DX11.Texture 2d)" filename="X:\StarBackground\PanoToSphere\PanoToSphere (DX11.Texture 2d).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Cubemap\PanoToSphere (DX11.Texture 2d).v4p" systemname="PanoToSphere (DX11.Texture 2d)" filename="X:\StarBackground\PanoToSphere\PanoToSphere (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="6765" top="8490" width="9000" height="6000">
    </BOUNDS>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="0">
@@ -29,6 +29,8 @@
    </PIN>
    <PIN pinname="Buffers" visible="1">
    </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
+   </PIN>
    </NODE>
    <NODE systemname="PanoToSphereDX11 (DX11.Effect)" filename="PanoToSphereDX11.fx" nodename="PanoToSphereDX11 (DX11.Effect)" componentmode="Hidden" id="4">
    <BOUNDS type="Node" left="2280" top="2385" width="100" height="100">
@@ -49,7 +51,7 @@
    </PIN>
    <PIN pinname="Technique" slicecount="1" values="_PanoToSphere">
    </PIN>
-   <PIN pinname="SphereMap Texture" visible="1">
+   <PIN pinname="SphereMap Texture" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="ClipBorder" slicecount="1" values="0">
    </PIN>
@@ -206,4 +208,6 @@
    </NODE>
    <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="4" dstpinname="ClipBorder">
    </LINK>
+   <PACK Name="addonpack" Version="33.7.0">
+   </PACK>
    </PATCH>

--- a/nodes/modules/Cubemap/SphereToPano (DX11.Texture 2d).v4p
+++ b/nodes/modules/Cubemap/SphereToPano (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.3.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\Cubemap\SphereToPano (DX11.Texture 2d).v4p" systemname="SphereToPano (DX11.Texture 2d)" filename="X:\StarBackground\SphereToPano\SphereToPano (DX11.Texture 2d).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Cubemap\SphereToPano (DX11.Texture 2d).v4p" systemname="SphereToPano (DX11.Texture 2d)" filename="X:\StarBackground\SphereToPano\SphereToPano (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="6765" top="8490" width="9000" height="6000">
    </BOUNDS>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="0">
@@ -29,6 +29,8 @@
    </PIN>
    <PIN pinname="Buffers" visible="1">
    </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
+   </PIN>
    </NODE>
    <NODE systemname="SphereToPanoDX11 (DX11.Effect)" filename="SphereToPanoDX11.fx" nodename="SphereToPanoDX11 (DX11.Effect)" componentmode="Hidden" id="4">
    <BOUNDS type="Node" left="2280" top="2385" width="100" height="100">
@@ -49,7 +51,7 @@
    </PIN>
    <PIN pinname="Technique" slicecount="1" values="_SphereToPano">
    </PIN>
-   <PIN pinname="SphereMap Texture" visible="1">
+   <PIN pinname="SphereMap Texture" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="SphereFactor" visible="1">
    </PIN>
@@ -186,6 +188,6 @@
    </NODE>
    <LINK srcnodeid="13" srcpinname="Y Output Value" dstnodeid="4" dstpinname="SphereFactor">
    </LINK>
-   <PACK Name="addonpack" Version="33.3.0">
+   <PACK Name="addonpack" Version="33.7.0">
    </PACK>
    </PATCH>

--- a/nodes/modules/DX11ToDX9 (DX11.Texture 2d).v4p
+++ b/nodes/modules/DX11ToDX9 (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\DX11ToDX9 (DX11.Texture 2d).v4p" systemname="DX11ToDX9 (DX11.Texture 2d)" filename="W:\projects\dx11-vvvv-girlpower\nodes\modules\DX11ToDX9 (DX11.Texture 2d).v4p" locked="0" scrollx="0" scrolly="1440">
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\DX11ToDX9 (DX11.Texture 2d).v4p" systemname="DX11ToDX9 (DX11.Texture 2d)" filename="W:\projects\dx11-vvvv-girlpower\nodes\modules\DX11ToDX9 (DX11.Texture 2d).v4p" locked="0" scrollx="0" scrolly="1440">
    <BOUNDS type="Window" left="5835" top="6225" width="8760" height="6780">
    </BOUNDS>
    <NODE systemname="AsSharedTexture (DX11.Texture 2d)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="AsSharedTexture (DX11.Texture 2d)" componentmode="Hidden" id="175">
@@ -103,7 +103,7 @@
    </BOUNDS>
    <PIN pinname="Transform" visible="1">
    </PIN>
-   <PIN pinname="Texture" visible="1">
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Layer" visible="1">
    </PIN>
@@ -144,6 +144,8 @@
    <PIN pinname="Enabled" visible="1" slicecount="1" values="1">
    </PIN>
    <PIN pinname="Query" visible="1">
+   </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    </NODE>
    <LINK srcnodeid="221" srcpinname="Output Enum" dstnodeid="222" dstpinname="Target Format">

--- a/nodes/modules/DepthReconstruction/DepthReconstruction (DX11.Texture 2d).v4p
+++ b/nodes/modules/DepthReconstruction/DepthReconstruction (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.2.dtd" >
-   <PATCH nodename="X:\DepthReconstruction\DepthReconstruction (DX11.Texture 2d).v4p" systemname="DepthReconstruction (DX11.Texture 2d)" filename="X:\DepthReconstruction\DepthReconstruction (DX11.Texture 2d).v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\DepthReconstruction\DepthReconstruction (DX11.Texture 2d).v4p" systemname="DepthReconstruction (DX11.Texture 2d)" filename="X:\DepthReconstruction\DepthReconstruction (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="11580" top="1155" width="11160" height="6735">
    </BOUNDS>
    <NODE systemname="DepthReconstruction (DX11.Effect)" filename="DepthReconstruction.fx" nodename="DepthReconstruction (DX11.Effect)" componentmode="Hidden" id="0">
@@ -27,7 +27,7 @@
    </BOUNDS>
    <PIN pinname="Layer" visible="1">
    </PIN>
-   <PIN pinname="Texture Input Mode" slicecount="1" values="InheritSize">
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    <PIN pinname="Enabled" visible="1">
    </PIN>
@@ -101,7 +101,7 @@
    </BOUNDS>
    <BOUNDS type="Node" left="5280" top="1890" width="0" height="0">
    </BOUNDS>
-   <PIN pinname="Input Node" slicecount="1" values="||" visible="1">
+   <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
    </PIN>
    <PIN pinname="Output Node" visible="1">
    </PIN>
@@ -233,7 +233,7 @@
    <NODE systemname="Multiply (Transform)" nodename="Multiply (Transform)" componentmode="Hidden" id="22">
    <BOUNDS type="Node" left="5295" top="1485" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Transform In 1" visible="1">
+   <PIN pinname="Transform In 1" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Transform In 2" visible="1" slicecount="1" values="||">
    </PIN>
@@ -256,4 +256,6 @@
    </LINK>
    <LINK srcnodeid="23" srcpinname="Transform Out" dstnodeid="22" dstpinname="Transform In 2">
    </LINK>
+   <PACK Name="addonpack" Version="33.7.0">
+   </PACK>
    </PATCH>

--- a/nodes/modules/Echo/Echo (DX11.Texture 2d).v4p
+++ b/nodes/modules/Echo/Echo (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\Echo\Echo (DX11.Texture 2d).v4p" systemname="Echo (DX11.Texture 2d)" filename="W:\Echo (DX11.Texture 2d).v4p">
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Echo\Echo (DX11.Texture 2d).v4p" systemname="Echo (DX11.Texture 2d)" filename="W:\Echo (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="14010" top="5100" width="10725" height="8295">
    </BOUNDS>
    <PACK Name="addonpack" Version="33.7.0">
@@ -13,7 +13,7 @@
    </PIN>
    <PIN pinname="Target Format" slicecount="1" values="R16G16B16A16_Float">
    </PIN>
-   <PIN pinname="Texture Input Mode" slicecount="1" values="InheritSize">
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
    </PIN>
@@ -233,7 +233,7 @@
    <NODE systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden" id="15">
    <BOUNDS type="Node" left="810" top="4740" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Switch" visible="1" slicecount="1" values="0">
+   <PIN pinname="Switch" visible="1">
    </PIN>
    <PIN pinname="Input 1" visible="1" slicecount="1" values="||">
    </PIN>
@@ -242,6 +242,8 @@
    <PIN pinname="Output" visible="1">
    </PIN>
    </NODE>
+   <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="15" dstpinname="Switch">
+   </LINK>
    <LINK srcnodeid="16" srcpinname="Layer" dstnodeid="15" dstpinname="Input 2">
    </LINK>
    <LINK srcnodeid="15" srcpinname="Output" dstnodeid="11" dstpinname="Layer">
@@ -473,31 +475,5 @@
    <LINK srcnodeid="26" srcpinname="Layer Out" dstnodeid="17" dstpinname="Input 1">
    </LINK>
    <LINK srcnodeid="9" srcpinname="Layer" dstnodeid="17" dstpinname="Input 2">
-   </LINK>
-   <NODE systemname="OR (Boolean)" nodename="OR (Boolean)" componentmode="Hidden" id="28">
-   <BOUNDS type="Node" left="7260" top="4440" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="28" dstpinname="Input 1">
-   </LINK>
-   <NODE systemname="TogEdge (Animation)" nodename="TogEdge (Animation)" componentmode="Hidden" id="29">
-   <BOUNDS type="Node" left="7425" top="4005" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Up Edge" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="13" srcpinname="Y Output Value" dstnodeid="29" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="29" srcpinname="Up Edge" dstnodeid="28" dstpinname="Input 2">
-   </LINK>
-   <LINK srcnodeid="28" srcpinname="Output" dstnodeid="15" dstpinname="Switch">
    </LINK>
    </PATCH>

--- a/nodes/modules/Resize (DX11.Texture 2d).v4p
+++ b/nodes/modules/Resize (DX11.Texture 2d).v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\Resize (DX11.Texture 2d).v4p" systemname="Resize (DX11.Texture 2d)" filename="X:\Resize (DX11.Texture 2d).v4p">
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\Resize (DX11.Texture 2d).v4p" systemname="Resize (DX11.Texture 2d)" filename="X:\Resize (DX11.Texture 2d).v4p">
    <BOUNDS type="Window" left="16185" top="7260" width="9000" height="6000">
    </BOUNDS>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="8" systemname="IOBox (Enumerations)">
@@ -123,6 +123,8 @@
    </BOUNDS>
    <PIN pinname="Texture ScaleXY" slicecount="2" values="1,1">
    </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
+   </PIN>
    </NODE>
    <LINK srcnodeid="8" srcpinname="Output Enum" dstnodeid="10" dstpinname="Target Format">
    </LINK>
@@ -187,7 +189,7 @@
    </PIN>
    <PIN pinname="Descriptive Name" slicecount="1" values="|Sampler State|">
    </PIN>
-   <PIN pinname="Pin Visibility" slicecount="1" values="True">
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
    </PIN>
    <PIN pinname="Output Node" visible="1">
    </PIN>

--- a/nodes/modules/WriterDX11NRT/Writer (DX11.Texture 2d NRT Advanced) help.v4p
+++ b/nodes/modules/WriterDX11NRT/Writer (DX11.Texture 2d NRT Advanced) help.v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta31.2.dtd" >
-   <PATCH nodename="X:\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced) help.v4p">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced) help.v4p">
    <BOUNDS type="Window" left="1005" top="180" width="13080" height="15270">
    </BOUNDS>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="3" systemname="IOBox (String)">
@@ -26,36 +26,6 @@
    <PIN pinname="String Type" slicecount="1" values="MultiLine">
    </PIN>
    </NODE>
-   <NODE nodename="Writer (DX11.Texture 2d NRT Advanced)" componentmode="Hidden" id="0" systemname="Writer (DX11.Texture 2d NRT Advanced)" filename="Writer (DX11.Texture 2d NRT Advanced).v4p">
-   <BOUNDS type="Node" left="3170" top="13750" width="5715" height="270">
-   </BOUNDS>
-   <BOUNDS type="Box" left="3170" top="13750" width="0" height="0">
-   </BOUNDS>
-   <BOUNDS type="Window" left="5040" top="1860" width="18885" height="10980">
-   </BOUNDS>
-   <PIN pinname="Shutter Time" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Preview Texture" visible="1">
-   </PIN>
-   <PIN pinname="Projection Jitter" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Frame Tile Count" visible="1" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Tile Index" visible="1">
-   </PIN>
-   <PIN pinname="Dithering Enabled" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Pause" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Write" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Maximum forground fps" slicecount="1" values="60">
-   </PIN>
-   <PIN pinname="Maximum background fpsS" slicecount="1" values="60">
-   </PIN>
-   </NODE>
    <NODE systemname="Renderer (DX11)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11)" componentmode="InAWindow" id="9">
    <BOUNDS type="Node" left="255" top="13695" width="100" height="100">
    </BOUNDS>
@@ -75,7 +45,7 @@
    </PIN>
    <PIN pinname="Layer" visible="1">
    </PIN>
-   <PIN pinname="Texture" visible="1">
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
    </PIN>
    </NODE>
    <NODE systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" id="11">
@@ -91,7 +61,7 @@
    <NODE systemname="Renderer (DX11 TempTarget)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11 TempTarget)" componentmode="Hidden" id="12">
    <BOUNDS type="Node" left="2385" top="11685" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Layer" visible="1">
+   <PIN pinname="Layer" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Target Format" slicecount="1" values="R16G16B16A16_Float">
    </PIN>
@@ -103,7 +73,7 @@
    </PIN>
    <PIN pinname="Buffers" visible="1">
    </PIN>
-   <PIN pinname="View" visible="1">
+   <PIN pinname="View" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Projection" visible="1">
    </PIN>
@@ -136,23 +106,7 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Texture SizeXY">
-   </LINK>
    <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="12" dstpinname="Texture SizeXY">
-   </LINK>
-   <LINK srcnodeid="0" srcpinname="Preview Texture" dstnodeid="10" dstpinname="Texture">
-   </LINK>
-   <NODE systemname="Camera (Transform Softimage)" filename="%VVVV%\lib\nodes\modules\Transform\Camera (Transform Softimage).v4p" nodename="Camera (Transform Softimage)" componentmode="Hidden" id="15">
-   <BOUNDS type="Node" left="6825" top="11655" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="View" visible="1">
-   </PIN>
-   <PIN pinname="Projection" visible="1">
-   </PIN>
-   <PIN pinname="Inital Distance" slicecount="1" values="2">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="15" srcpinname="View" dstnodeid="12" dstpinname="View">
    </LINK>
    <NODE systemname="AspectRatio (Transform)" nodename="AspectRatio (Transform)" componentmode="Hidden" id="21">
    <BOUNDS type="Node" left="8640" top="11880" width="100" height="100">
@@ -167,7 +121,7 @@
    <NODE systemname="Multiply (Transform)" nodename="Multiply (Transform)" componentmode="Hidden" id="22">
    <BOUNDS type="Node" left="7995" top="12270" width="1500" height="270">
    </BOUNDS>
-   <PIN pinname="Transform In 1" visible="1">
+   <PIN pinname="Transform In 1" visible="1" slicecount="1" values="||">
    </PIN>
    <PIN pinname="Transform Out" visible="1">
    </PIN>
@@ -178,8 +132,6 @@
    <PIN pinname="Transform In 3" visible="1" slicecount="1" values="||">
    </PIN>
    </NODE>
-   <LINK srcnodeid="15" srcpinname="Projection" dstnodeid="22" dstpinname="Transform In 1">
-   </LINK>
    <LINK srcnodeid="21" srcpinname="Transform Out" dstnodeid="22" dstpinname="Transform In 2">
    </LINK>
    <NODE systemname="Vector (2d Split)" nodename="Vector (2d Split)" componentmode="Hidden" id="23">
@@ -199,12 +151,6 @@
    <LINK srcnodeid="23" srcpinname="Y" dstnodeid="21" dstpinname="Aspect Width">
    </LINK>
    <LINK srcnodeid="22" srcpinname="Transform Out" dstnodeid="12" dstpinname="Projection">
-   </LINK>
-   <LINK srcnodeid="0" srcpinname="Projection Jitter" dstnodeid="22" dstpinname="Transform In 3">
-   <LINKPOINT x="9855" y="14190">
-   </LINKPOINT>
-   <LINKPOINT x="10065" y="11565">
-   </LINKPOINT>
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="76" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="6930" top="12540" width="480" height="480">
@@ -226,8 +172,6 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="Write">
    </PIN>
    </NODE>
-   <LINK srcnodeid="76" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Write">
-   </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="77" systemname="IOBox (String)">
    <BOUNDS type="Box" left="4590" top="12705" width="1965" height="240">
    </BOUNDS>
@@ -246,8 +190,6 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="Path">
    </PIN>
    </NODE>
-   <LINK srcnodeid="77" srcpinname="Output String" dstnodeid="0" dstpinname="Path">
-   </LINK>
    <NODE systemname="TypoSpread (Spreads)" nodename="TypoSpread (Spreads)" componentmode="Hidden" id="78">
    <BOUNDS type="Node" left="1875" top="7605" width="2535" height="270">
    </BOUNDS>
@@ -434,26 +376,6 @@
    </LINK>
    <LINK srcnodeid="98" srcpinname="Y Output Value" dstnodeid="91" dstpinname="Enabled">
    </LINK>
-   <NODE systemname="Line (DX11)" filename="%VVVV%\packs\DX11\nodes\modules\Line (DX11).v4p" nodename="Line (DX11)" componentmode="Hidden" id="99">
-   <BOUNDS type="Node" left="2535" top="11295" width="3150" height="270">
-   </BOUNDS>
-   <PIN pinname="VerticesXYZ" visible="1">
-   </PIN>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Single Input" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="BinSize" slicecount="1" visible="1" values="-1">
-   </PIN>
-   <PIN pinname="Antialias" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Width" slicecount="1024" visible="1" values="4">
-   </PIN>
-   <PIN pinname="PatternScale" slicecount="1" values="3">
-   </PIN>
-   <PIN pinname="Color" visible="1">
-   </PIN>
-   </NODE>
    <NODE systemname="xyZ (3d XY)" nodename="xyZ (3d XY)" componentmode="Hidden" id="100">
    <BOUNDS type="Node" left="2115" top="11310" width="100" height="100">
    </BOUNDS>
@@ -464,8 +386,6 @@
    <PIN pinname="Z" slicecount="1" values="0">
    </PIN>
    </NODE>
-   <LINK srcnodeid="99" srcpinname="Layer" dstnodeid="12" dstpinname="Layer">
-   </LINK>
    <NODE systemname="Select (Value)" nodename="Select (Value)" componentmode="Hidden" id="105">
    <BOUNDS type="Node" left="3075" top="10305" width="100" height="100">
    </BOUNDS>
@@ -584,8 +504,6 @@
    </LINK>
    <LINK srcnodeid="105" srcpinname="Output" dstnodeid="94" dstpinname="FilterTime">
    </LINK>
-   <LINK srcnodeid="100" srcpinname="XYZ" dstnodeid="99" dstpinname="VerticesXYZ">
-   </LINK>
    <LINK srcnodeid="94" srcpinname="Position Out" dstnodeid="100" dstpinname="XY">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="117" systemname="IOBox (Value Advanced)">
@@ -604,8 +522,6 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="|Frame Sample Count|">
    </PIN>
    </NODE>
-   <LINK srcnodeid="117" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Frame Sample Count">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="118" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="8790" top="12600" width="795" height="240">
    </BOUNDS>
@@ -622,8 +538,6 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="|Target Framerate|">
    </PIN>
    </NODE>
-   <LINK srcnodeid="118" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Target Framerate">
-   </LINK>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="119" systemname="IOBox (Enumerations)">
    <BOUNDS type="Box" left="5985" top="13230" width="570" height="240">
    </BOUNDS>
@@ -634,8 +548,6 @@
    <PIN pinname="Descriptive Name" slicecount="1" values="Format">
    </PIN>
    </NODE>
-   <LINK srcnodeid="119" srcpinname="Output Enum" dstnodeid="0" dstpinname="Format">
-   </LINK>
    <NODE systemname="Ord2Enum (Enumerations)" nodename="Ord2Enum (Enumerations)" componentmode="Hidden" id="120">
    <BOUNDS type="Node" left="3765" top="7095" width="100" height="100">
    </BOUNDS>
@@ -747,8 +659,6 @@
    <LINK srcnodeid="124" srcpinname="Output" dstnodeid="128" dstpinname="Input">
    </LINK>
    <LINK srcnodeid="78" srcpinname="BinSize" dstnodeid="128" dstpinname="Select">
-   </LINK>
-   <LINK srcnodeid="126" srcpinname="Output" dstnodeid="99" dstpinname="Color">
    </LINK>
    <LINK srcnodeid="127" srcpinname="Position Out" dstnodeid="126" dstpinname="Hue">
    </LINK>
@@ -1042,8 +952,6 @@
    </NODE>
    <LINK srcnodeid="149" srcpinname="Texture Out" dstnodeid="157" dstpinname="Texture In">
    </LINK>
-   <LINK srcnodeid="157" srcpinname="Texture Out" dstnodeid="0" dstpinname="Texture">
-   </LINK>
    <NODE systemname="Random (Value)" nodename="Random (Value)" componentmode="Hidden" id="158">
    <BOUNDS type="Node" left="10080" top="7365" width="100" height="100">
    </BOUNDS>
@@ -1170,8 +1078,6 @@
    </NODE>
    <LINK srcnodeid="161" srcpinname="Output" dstnodeid="170" dstpinname="Input 1">
    </LINK>
-   <LINK srcnodeid="170" srcpinname="Output" dstnodeid="99" dstpinname="Width">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="172" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="10125" top="10335" width="795" height="240">
    </BOUNDS>
@@ -1286,7 +1192,7 @@
    </LINK>
    <LINK srcnodeid="179" srcpinname="Output" dstnodeid="80" dstpinname="Input String">
    </LINK>
-   <NODE systemname="FrameDelay (Animation)" nodename="FrameDelay (Animation)" componentmode="Hidden" id="183">
+   <NODE systemname="FrameDelay (Animation Legacy)" nodename="FrameDelay (Animation)" componentmode="Hidden" id="183">
    <BOUNDS type="Node" left="285" top="6870" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Input 1" visible="1">
@@ -1360,4 +1266,102 @@
    <PIN pinname="Size" slicecount="1" values="12">
    </PIN>
    </NODE>
+   <NODE systemname="Camera (Transform Softimage)" filename="..\..\..\..\..\..\..\public-vl\VL.EditingFramework\vvvv\nodes\modules\Camera (Transform Softimage).v4p" nodename="Camera (Transform Softimage)" componentmode="Hidden" id="15">
+   <BOUNDS type="Node" left="6825" top="11655" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="View" visible="1">
+   </PIN>
+   <PIN pinname="Projection" visible="1">
+   </PIN>
+   <PIN pinname="Initial Distance" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="15" srcpinname="View" dstnodeid="12" dstpinname="View">
+   </LINK>
+   <LINK srcnodeid="15" srcpinname="Projection" dstnodeid="22" dstpinname="Transform In 1">
+   </LINK>
+   <PACK Name="dx11" Version="0.7.2">
+   </PACK>
+   <PACK Name="addonpack" Version="33.7.0">
+   </PACK>
+   <NODE systemname="Line (DX11)" filename="%VVVV%\packs\dx11\nodes\modules\Line (DX11).v4p" nodename="Line (DX11)" componentmode="Hidden" id="99">
+   <BOUNDS type="Node" left="2535" top="11295" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="VerticesXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Single Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="BinSize" slicecount="1" visible="1" values="-1">
+   </PIN>
+   <PIN pinname="Antialias" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Width" slicecount="1024" visible="1" values="4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,">
+   </PIN>
+   <PIN pinname="PatternScale" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Color" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="99" srcpinname="Layer" dstnodeid="12" dstpinname="Layer">
+   </LINK>
+   <LINK srcnodeid="100" srcpinname="XYZ" dstnodeid="99" dstpinname="VerticesXYZ">
+   </LINK>
+   <LINK srcnodeid="126" srcpinname="Output" dstnodeid="99" dstpinname="Color">
+   </LINK>
+   <LINK srcnodeid="170" srcpinname="Output" dstnodeid="99" dstpinname="Width">
+   </LINK>
+   <NODE nodename="Writer (DX11.Texture 2d NRT Advanced)" componentmode="Hidden" id="0" systemname="Writer (DX11.Texture 2d NRT Advanced)" filename="Writer (DX11.Texture 2d NRT Advanced).v4p">
+   <BOUNDS type="Node" left="3170" top="13750" width="5715" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3170" top="13750" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Window" left="5040" top="1860" width="18885" height="10980">
+   </BOUNDS>
+   <PIN pinname="Shutter Time" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Texture" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Preview Texture" visible="1">
+   </PIN>
+   <PIN pinname="Projection Jitter" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Frame Tile Count" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Tile Index" visible="1">
+   </PIN>
+   <PIN pinname="Dithering Enabled" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Pause" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Write" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum forground fps" slicecount="1" values="60">
+   </PIN>
+   <PIN pinname="Maximum background fpsS" slicecount="1" values="60">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="14" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Texture SizeXY">
+   </LINK>
+   <LINK srcnodeid="0" srcpinname="Preview Texture" dstnodeid="10" dstpinname="Texture">
+   </LINK>
+   <LINK srcnodeid="0" srcpinname="Projection Jitter" dstnodeid="22" dstpinname="Transform In 3">
+   <LINKPOINT x="9855" y="14190">
+   </LINKPOINT>
+   <LINKPOINT x="10065" y="11565">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="76" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Write">
+   </LINK>
+   <LINK srcnodeid="77" srcpinname="Output String" dstnodeid="0" dstpinname="Path">
+   </LINK>
+   <LINK srcnodeid="117" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Frame Sample Count">
+   </LINK>
+   <LINK srcnodeid="118" srcpinname="Y Output Value" dstnodeid="0" dstpinname="Target Framerate">
+   </LINK>
+   <LINK srcnodeid="119" srcpinname="Output Enum" dstnodeid="0" dstpinname="Format">
+   </LINK>
+   <LINK srcnodeid="157" srcpinname="Texture Out" dstnodeid="0" dstpinname="Texture">
+   </LINK>
    </PATCH>

--- a/nodes/modules/WriterDX11NRT/Writer (DX11.Texture 2d NRT Advanced).v4p
+++ b/nodes/modules/WriterDX11NRT/Writer (DX11.Texture 2d NRT Advanced).v4p
@@ -1,6 +1,6 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta33.7.dtd" >
-   <PATCH nodename="W:\projects\dx11-vvvv-girlpower\nodes\modules\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced).v4p" systemname="Writer (DX11.Texture 2d NRT Advanced)" filename="X:\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced).v4p" scrollx="45" scrolly="3240">
-   <BOUNDS type="Window" left="7710" top="7380" width="18885" height="10980">
+   <PATCH nodename="C:\Work\dx11-vvvv-girlpower\nodes\modules\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced).v4p" systemname="Writer (DX11.Texture 2d NRT Advanced)" filename="X:\WriterDX11NRT\Writer (DX11.Texture 2d NRT Advanced).v4p" scrollx="0" scrolly="1800">
+   <BOUNDS type="Window" left="5040" top="1860" width="18885" height="10980">
    </BOUNDS>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="1" systemname="IOBox (Enumerations)">
    <BOUNDS type="Box" left="285" top="4860" width="2070" height="240">
@@ -15,11 +15,11 @@
    <NODE systemname="MAINLOOP (VVVV)" nodename="MainLoop (VVVV)" componentmode="Hidden" id="-6">
    <BOUNDS type="Node" left="20100" top="6705" width="3480" height="270">
    </BOUNDS>
-   <PIN pinname="Maximum background fpsS" visible="1">
+   <PIN pinname="Maximum Background FPS" visible="1">
    </PIN>
    <PIN pinname="Time Mode" visible="1" slicecount="1" values="Raw">
    </PIN>
-   <PIN pinname="Maximum forground fps" visible="1">
+   <PIN pinname="Maximum Foreground FPS" visible="1">
    </PIN>
    <PIN pinname="Increase Timing Precision" visible="1" pintype="Input" slicecount="1" values="0">
    </PIN>
@@ -244,12 +244,12 @@
    </LINK>
    <LINK srcnodeid="26" srcpinname="Y Output Value" dstnodeid="30" dstpinname="Input 1">
    </LINK>
-   <LINK srcnodeid="30" srcpinname="Output" dstnodeid="-6" dstpinname="Maximum background fpsS">
+   <LINK srcnodeid="30" srcpinname="Output" dstnodeid="-6" dstpinname="Maximum Background FPS">
    </LINK>
-   <LINK srcnodeid="29" srcpinname="Output" dstnodeid="-6" dstpinname="Maximum forground fps">
+   <LINK srcnodeid="29" srcpinname="Output" dstnodeid="-6" dstpinname="Maximum Foreground FPS">
    </LINK>
    <NODE systemname="Quad (DX11.Layer)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Quad (DX11.Layer)" componentmode="Hidden" id="32">
-   <BOUNDS type="Node" left="450" top="3270" width="100" height="100">
+   <BOUNDS type="Node" left="405" top="4125" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Layer" visible="1">
    </PIN>
@@ -277,7 +277,7 @@
    <LINK srcnodeid="33" srcpinname="Output Node" dstnodeid="32" dstpinname="Texture">
    </LINK>
    <NODE systemname="UniformScale (Transform)" nodename="UniformScale (Transform)" componentmode="Hidden" id="34">
-   <BOUNDS type="Node" left="420" top="2940" width="100" height="100">
+   <BOUNDS type="Node" left="375" top="3795" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Transform Out" visible="1">
    </PIN>
@@ -287,9 +287,9 @@
    <LINK srcnodeid="34" srcpinname="Transform Out" dstnodeid="32" dstpinname="Transform">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="35" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="1440" top="2940" width="285" height="240">
+   <BOUNDS type="Box" left="1395" top="3795" width="285" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="1440" top="2940" width="0" height="0">
+   <BOUNDS type="Node" left="1395" top="3795" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" values="2">
    </PIN>
@@ -362,14 +362,6 @@
    <PIN pinname="Show Grid" slicecount="1" values="1">
    </PIN>
    <PIN pinname="String Type" slicecount="1" values="MultiLine">
-   </PIN>
-   </NODE>
-   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="39">
-   <BOUNDS type="Node" left="7335" top="6870" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Maximum" visible="1">
-   </PIN>
-   <PIN pinname="Up" visible="1">
    </PIN>
    </NODE>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="41">
@@ -462,8 +454,6 @@
    </NODE>
    <LINK srcnodeid="46" srcpinname="Y Output Value" dstnodeid="45" dstpinname="Input 2">
    </LINK>
-   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="39" dstpinname="Maximum">
-   </LINK>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="47">
    <BOUNDS type="Node" left="7335" top="5670" width="100" height="100">
    </BOUNDS>
@@ -480,8 +470,6 @@
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
    </PIN>
    </NODE>
-   <LINK srcnodeid="47" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Up">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="48" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="7335" top="7170" width="795" height="240">
    </BOUNDS>
@@ -496,8 +484,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="39" srcpinname="Output" dstnodeid="48" dstpinname="Y Input Value">
-   </LINK>
    <NODE systemname="EQ (Value)" nodename="EQ (Value)" componentmode="Hidden" id="49">
    <BOUNDS type="Node" left="7335" top="7485" width="100" height="100">
    </BOUNDS>
@@ -550,16 +536,6 @@
    <PIN pinname="X Input Value" slicecount="1" values="0">
    </PIN>
    </NODE>
-   <LINK srcnodeid="52" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Reset">
-   </LINK>
-   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="77">
-   <BOUNDS type="Node" left="9285" top="6870" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Maximum" visible="1">
-   </PIN>
-   <PIN pinname="Up" visible="1">
-   </PIN>
-   </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="76" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="9420" top="6225" width="795" height="240">
    </BOUNDS>
@@ -608,8 +584,6 @@
    </NODE>
    <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="75" dstpinname="Input 2">
    </LINK>
-   <LINK srcnodeid="75" srcpinname="Output" dstnodeid="77" dstpinname="Maximum">
-   </LINK>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="73">
    <BOUNDS type="Node" left="9285" top="5655" width="100" height="100">
    </BOUNDS>
@@ -626,8 +600,6 @@
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="73" srcpinname="Y Output Value" dstnodeid="77" dstpinname="Up">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="72" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="9285" top="7170" width="795" height="240">
    </BOUNDS>
@@ -642,8 +614,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="77" srcpinname="Output" dstnodeid="72" dstpinname="Y Input Value">
-   </LINK>
    <NODE systemname="EQ (Value)" nodename="EQ (Value)" componentmode="Hidden" id="71">
    <BOUNDS type="Node" left="9285" top="7485" width="100" height="100">
    </BOUNDS>
@@ -694,20 +664,6 @@
    <PIN pinname="X Input Value" slicecount="1" values="0">
    </PIN>
    </NODE>
-   <LINK srcnodeid="69" srcpinname="Y Output Value" dstnodeid="77" dstpinname="Reset">
-   </LINK>
-   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="86">
-   <BOUNDS type="Node" left="11235" top="6870" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Maximum" visible="1">
-   </PIN>
-   <PIN pinname="Up" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   <PIN pinname="Mode" slicecount="1" values="Unlimited">
-   </PIN>
-   </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="85" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="11370" top="6225" width="795" height="240">
    </BOUNDS>
@@ -756,8 +712,6 @@
    </NODE>
    <LINK srcnodeid="83" srcpinname="Y Output Value" dstnodeid="84" dstpinname="Input 2">
    </LINK>
-   <LINK srcnodeid="84" srcpinname="Output" dstnodeid="86" dstpinname="Maximum">
-   </LINK>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="82">
    <BOUNDS type="Node" left="11235" top="5655" width="100" height="100">
    </BOUNDS>
@@ -774,8 +728,6 @@
    <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="82" srcpinname="Y Output Value" dstnodeid="86" dstpinname="Up">
-   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="81" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="11235" top="7170" width="795" height="240">
    </BOUNDS>
@@ -790,8 +742,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="86" srcpinname="Output" dstnodeid="81" dstpinname="Y Input Value">
-   </LINK>
    <NODE systemname="EQ (Value)" nodename="EQ (Value)" componentmode="Hidden" id="80">
    <BOUNDS type="Node" left="11235" top="7485" width="100" height="100">
    </BOUNDS>
@@ -846,8 +796,6 @@
    <PIN pinname="X Input Value" slicecount="1" values="0">
    </PIN>
    </NODE>
-   <LINK srcnodeid="78" srcpinname="Y Output Value" dstnodeid="86" dstpinname="Reset">
-   </LINK>
    <LINK srcnodeid="50" srcpinname="Y Output Value" dstnodeid="73" dstpinname="Y Input Value">
    <LINKPOINT x="7380" y="9030">
    </LINKPOINT>
@@ -1134,8 +1082,6 @@
    <PIN pinname="Input Enum" slicecount="1" values="Wrap">
    </PIN>
    </NODE>
-   <LINK srcnodeid="114" srcpinname="Output Enum" dstnodeid="77" dstpinname="Mode">
-   </LINK>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="115" systemname="IOBox (Enumerations)">
    <BOUNDS type="Box" left="8385" top="6495" width="495" height="240">
    </BOUNDS>
@@ -1144,8 +1090,6 @@
    <PIN pinname="Input Enum" slicecount="1" values="Wrap">
    </PIN>
    </NODE>
-   <LINK srcnodeid="115" srcpinname="Output Enum" dstnodeid="39" dstpinname="Mode">
-   </LINK>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="116" systemname="IOBox (Enumerations)">
    <BOUNDS type="Box" left="12285" top="6510" width="615" height="240">
    </BOUNDS>
@@ -1154,8 +1098,6 @@
    <PIN pinname="Input Enum" slicecount="1" values="Unlimited">
    </PIN>
    </NODE>
-   <LINK srcnodeid="116" srcpinname="Output Enum" dstnodeid="86" dstpinname="Mode">
-   </LINK>
    <NODE systemname="Switch (Value Input)" nodename="Switch (Value Input)" componentmode="Hidden" id="118">
    <BOUNDS type="Node" left="13650" top="2970" width="900" height="270">
    </BOUNDS>
@@ -1651,7 +1593,7 @@
    <LINK srcnodeid="176" srcpinname="Y Output Value" dstnodeid="175" dstpinname="Alpha">
    </LINK>
    <NODE systemname="RGB (Color Join)" nodename="RGB (Color Join)" componentmode="Hidden" id="177">
-   <BOUNDS type="Node" left="2280" top="3945" width="100" height="100">
+   <BOUNDS type="Node" left="2010" top="3735" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Green" visible="1">
    </PIN>
@@ -1663,9 +1605,9 @@
    </PIN>
    </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="178" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="2295" top="3465" width="795" height="240">
+   <BOUNDS type="Box" left="2025" top="3255" width="795" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="2295" top="3465" width="0" height="0">
+   <BOUNDS type="Node" left="2025" top="3255" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" values="0">
    </PIN>
@@ -1685,7 +1627,7 @@
    <LINK srcnodeid="178" srcpinname="Y Output Value" dstnodeid="177" dstpinname="Alpha">
    </LINK>
    <NODE systemname="Renderer (DX11 TempTarget)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11 TempTarget)" componentmode="Hidden" id="179">
-   <BOUNDS type="Node" left="285" top="9195" width="100" height="100">
+   <BOUNDS type="Node" left="255" top="8835" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Texture SizeXY" visible="1">
    </PIN>
@@ -1697,11 +1639,13 @@
    </PIN>
    <PIN pinname="Clear Depth" visible="1">
    </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
+   </PIN>
    </NODE>
    <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="180" systemname="IOBox (Enumerations)">
-   <BOUNDS type="Box" left="285" top="8835" width="1590" height="240">
+   <BOUNDS type="Box" left="255" top="8475" width="1590" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="285" top="8835" width="0" height="0">
+   <BOUNDS type="Node" left="255" top="8475" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input Enum" slicecount="1" values="R8G8B8A8_UNorm">
    </PIN>
@@ -1709,7 +1653,7 @@
    <LINK srcnodeid="180" srcpinname="Output Enum" dstnodeid="179" dstpinname="Target Format">
    </LINK>
    <NODE systemname="Blend (DX11.RenderState Advanced)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Blend (DX11.RenderState Advanced)" componentmode="Hidden" id="181">
-   <BOUNDS type="Node" left="435" top="2580" width="100" height="100">
+   <BOUNDS type="Node" left="390" top="3435" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Mode">
    </PIN>
@@ -1753,13 +1697,19 @@
    </PIN>
    <PIN pinname="Write" visible="1">
    </PIN>
-   <PIN pinname="Create Folder" visible="1" pintype="Input" slicecount="1" values="0">
+   </NODE>
+   <NODE systemname="Directory (File)" filename="%VVVV%\addonpack\lib\nodes\plugins\Directory.dll" nodename="Directory (File)" componentmode="Hidden" id="185">
+   <BOUNDS type="Node" left="3315" top="10800" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Exists" visible="1">
+   </PIN>
+   <PIN pinname="Create" visible="1">
    </PIN>
    </NODE>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="186" systemname="IOBox (String)">
-   <BOUNDS type="Box" left="3690" top="9480" width="1170" height="240">
+   <BOUNDS type="Box" left="3120" top="9345" width="1170" height="240">
    </BOUNDS>
-   <BOUNDS type="Node" left="3690" top="9480" width="0" height="0">
+   <BOUNDS type="Node" left="3120" top="9345" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Input String" slicecount="1" values="X:\render">
    </PIN>
@@ -1776,6 +1726,28 @@
    <PIN pinname="Output String" visible="1">
    </PIN>
    </NODE>
+   <LINK srcnodeid="186" srcpinname="Output String" dstnodeid="185" dstpinname="Directory">
+   </LINK>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="189">
+   <BOUNDS type="Node" left="3975" top="10425" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="NOT (Boolean)" nodename="NOT (Boolean)" componentmode="Hidden" id="190">
+   <BOUNDS type="Node" left="3975" top="11190" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="185" srcpinname="Exists" dstnodeid="190" dstpinname="Input">
+   </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="191" systemname="IOBox (Value Advanced)">
    <BOUNDS type="Box" left="5700" top="1305" width="480" height="480">
    </BOUNDS>
@@ -1817,6 +1789,26 @@
    <LINK srcnodeid="105" srcpinname="Up Edge" dstnodeid="192" dstpinname="Y Input Value">
    </LINK>
    <LINK srcnodeid="192" srcpinname="Y Output Value" dstnodeid="171" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="193" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="4380" top="10005" width="375" height="360">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4380" top="10005" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="193" srcpinname="Y Output Value" dstnodeid="189" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="192" srcpinname="Y Output Value" dstnodeid="189" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="189" srcpinname="Output" dstnodeid="185" dstpinname="Create">
    </LINK>
    <NODE systemname="FormatValue (String)" nodename="FormatValue (String)" componentmode="Hidden" id="194">
    <BOUNDS type="Node" left="5835" top="12705" width="100" height="100">
@@ -2415,8 +2407,6 @@
    </PIN>
    <PIN pinname="Enabled" visible="1" slicecount="1" values="1">
    </PIN>
-   <PIN pinname="Uniform" visible="1">
-   </PIN>
    </NODE>
    <NODE systemname="Quad (DX11.Geometry)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Quad (DX11.Geometry)" componentmode="Hidden" id="243">
    <BOUNDS type="Node" left="465" top="7020" width="100" height="100">
@@ -2429,6 +2419,8 @@
    <LINK srcnodeid="243" srcpinname="Geometry Out" dstnodeid="242" dstpinname="Geometry">
    </LINK>
    <LINK srcnodeid="232" srcpinname="Output" dstnodeid="242" dstpinname="Color">
+   </LINK>
+   <LINK srcnodeid="242" srcpinname="Layer" dstnodeid="179" dstpinname="Layer">
    </LINK>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="244">
    <BOUNDS type="Node" left="450" top="6675" width="100" height="100">
@@ -2448,8 +2440,6 @@
    <BOUNDS type="Node" left="1515" top="6945" width="100" height="100">
    </BOUNDS>
    <PIN pinname="Output" visible="1">
-   </PIN>
-   <PIN pinname="Enabled" slicecount="1" values="1">
    </PIN>
    </NODE>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="248" systemname="IOBox (Value Advanced)">
@@ -2484,6 +2474,14 @@
    <PIN pinname="String Value" visible="1">
    </PIN>
    <PIN pinname="Enum" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Enum2String (Enumerations)" nodename="Enum2String (Enumerations)" componentmode="Hidden" id="252">
+   <BOUNDS type="Node" left="3510" top="585" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enum" visible="1">
+   </PIN>
+   <PIN pinname="String Value" visible="1">
    </PIN>
    </NODE>
    <NODE systemname="OR (Boolean)" nodename="OR (Boolean)" componentmode="Hidden" id="253">
@@ -2536,6 +2534,8 @@
    </NODE>
    <LINK srcnodeid="255" srcpinname="Y Output Value" dstnodeid="242" dstpinname="Grain">
    </LINK>
+   <LINK srcnodeid="1" srcpinname="Output Enum" dstnodeid="252" dstpinname="Enum">
+   </LINK>
    <NODE nodename="IOBox (String)" componentmode="InABox" id="256" systemname="IOBox (String)">
    <BOUNDS type="Box" left="3615" top="1470" width="795" height="240">
    </BOUNDS>
@@ -2573,9 +2573,11 @@
    </PIN>
    </NODE>
    <NODE systemname="Renderer (DX11 TempTarget)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11 TempTarget)" componentmode="Hidden" id="258">
-   <BOUNDS type="Node" left="285" top="5265" width="2400" height="270">
+   <BOUNDS type="Node" left="285" top="5220" width="2400" height="270">
    </BOUNDS>
    <PIN pinname="Buffers" visible="1">
+   </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="Inherit">
    </PIN>
    </NODE>
    <LINK srcnodeid="1" srcpinname="Output Enum" dstnodeid="258" dstpinname="Target Format">
@@ -2605,9 +2607,9 @@
    <LINK srcnodeid="256" srcpinname="Output String" dstnodeid="259" dstpinname="Input 1">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="260" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3105" top="525" width="480" height="480">
+   <BOUNDS type="Box" left="3075" top="750" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="3105" top="525" width="0" height="0">
+   <BOUNDS type="Node" left="3075" top="750" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Y Input Value" slicecount="1" values="1">
    </PIN>
@@ -2801,9 +2803,9 @@
    <LINK srcnodeid="274" srcpinname="Y Output Value" dstnodeid="205" dstpinname="Switch">
    </LINK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="275" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="1155" top="8250" width="480" height="480">
+   <BOUNDS type="Box" left="2190" top="8175" width="480" height="480">
    </BOUNDS>
-   <BOUNDS type="Node" left="1155" top="8250" width="0" height="0">
+   <BOUNDS type="Node" left="2190" top="8175" width="0" height="0">
    </BOUNDS>
    <PIN pinname="Units" slicecount="1" values="||">
    </PIN>
@@ -2888,6 +2890,26 @@
    </LINK>
    <LINK srcnodeid="283" srcpinname="Output" dstnodeid="242" dstpinname="Enabled">
    </LINK>
+   <NODE systemname="FrameDelay (Animation Legacy)" nodename="FrameDelay (Animation)" componentmode="Hidden" id="188">
+   <BOUNDS type="Node" left="3975" top="11535" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="190" srcpinname="Output" dstnodeid="188" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="Output 1" dstnodeid="193" dstpinname="Y Input Value">
+   <LINKPOINT x="3990" y="11820">
+   </LINKPOINT>
+   <LINKPOINT x="3990" y="12045">
+   </LINKPOINT>
+   <LINKPOINT x="4965" y="12045">
+   </LINKPOINT>
+   <LINKPOINT x="4965" y="9750">
+   </LINKPOINT>
+   <LINKPOINT x="4425" y="9750">
+   </LINKPOINT>
+   </LINK>
    <NODE systemname="OR (Boolean)" nodename="OR (Boolean)" componentmode="Hidden" id="285">
    <BOUNDS type="Node" left="12435" top="10260" width="100" height="100">
    </BOUNDS>
@@ -2916,234 +2938,62 @@
    </LINK>
    <PACK Name="addonpack" Version="33.7.0">
    </PACK>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="287" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="4305" top="10110" width="480" height="480">
+   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="39">
+   <BOUNDS type="Node" left="7335" top="6870" width="100" height="100">
    </BOUNDS>
-   <BOUNDS type="Node" left="4305" top="10110" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   <PIN pinname="Maximum" visible="1">
    </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Value Type" slicecount="1" values="Boolean">
-   </PIN>
-   <PIN pinname="Behavior" slicecount="1" values="Toggle">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="|Create Folder|">
-   </PIN>
-   <PIN pinname="X Input Value" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   <PIN pinname="Up" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="287" srcpinname="Y Output Value" dstnodeid="184" dstpinname="Create Folder">
+   <LINK srcnodeid="45" srcpinname="Output" dstnodeid="39" dstpinname="Maximum">
    </LINK>
-   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="288">
-   <BOUNDS type="Node" left="10005" top="12630" width="100" height="100">
+   <LINK srcnodeid="47" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Up">
+   </LINK>
+   <LINK srcnodeid="39" srcpinname="Output" dstnodeid="48" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="52" srcpinname="Y Output Value" dstnodeid="39" dstpinname="Reset">
+   </LINK>
+   <LINK srcnodeid="115" srcpinname="Output Enum" dstnodeid="39" dstpinname="Mode">
+   </LINK>
+   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="77">
+   <BOUNDS type="Node" left="9285" top="6870" width="100" height="100">
    </BOUNDS>
-   <PIN pinname="Input" visible="1">
+   <PIN pinname="Maximum" visible="1">
    </PIN>
-   <PIN pinname="Input 2" visible="1">
+   <PIN pinname="Up" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="75" srcpinname="Output" dstnodeid="77" dstpinname="Maximum">
+   </LINK>
+   <LINK srcnodeid="73" srcpinname="Y Output Value" dstnodeid="77" dstpinname="Up">
+   </LINK>
+   <LINK srcnodeid="77" srcpinname="Output" dstnodeid="72" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="69" srcpinname="Y Output Value" dstnodeid="77" dstpinname="Reset">
+   </LINK>
+   <LINK srcnodeid="114" srcpinname="Output Enum" dstnodeid="77" dstpinname="Mode">
+   </LINK>
+   <NODE systemname="Counter (Animation)" nodename="Counter (Animation)" componentmode="Hidden" id="86">
+   <BOUNDS type="Node" left="11235" top="6870" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Maximum" visible="1">
+   </PIN>
+   <PIN pinname="Up" visible="1">
    </PIN>
    <PIN pinname="Output" visible="1">
    </PIN>
-   </NODE>
-   <NODE systemname="FullscreenQuad (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\modules\FullscreenQuad (DX11.Layer).v4p" nodename="FullscreenQuad (DX11.Layer)" componentmode="Hidden" id="289">
-   <BOUNDS type="Node" left="2175" top="8790" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Render State" visible="1">
-   </PIN>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Enabled" visible="1">
-   </PIN>
-   <PIN pinname="Color" visible="1" slicecount="1" values="|0.00000,0.00000,0.00000,1.00000|">
+   <PIN pinname="Mode" slicecount="1" values="Unlimited">
    </PIN>
    </NODE>
-   <NODE systemname="Blend (DX11.RenderState Advanced)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Blend (DX11.RenderState Advanced)" componentmode="Hidden" id="290">
-   <BOUNDS type="Node" left="2160" top="8415" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Render State" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Enabled" slicecount="1" values="1">
-   </PIN>
-   <PIN pinname="Operation" slicecount="1" values="Add">
-   </PIN>
-   <PIN pinname="Alpha Operation" slicecount="1" values="Add">
-   </PIN>
-   <PIN pinname="Source Blend" slicecount="1" values="One">
-   </PIN>
-   <PIN pinname="Destination Blend" slicecount="1" values="One">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="290" srcpinname="Render State" dstnodeid="289" dstpinname="Render State">
+   <LINK srcnodeid="84" srcpinname="Output" dstnodeid="86" dstpinname="Maximum">
    </LINK>
-   <NODE systemname="Group (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Group (DX11.Layer)" componentmode="Hidden" id="291">
-   <BOUNDS type="Node" left="390" top="8085" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Layer 1" visible="1">
-   </PIN>
-   <PIN pinname="Layer 2" visible="1">
-   </PIN>
-   <PIN pinname="Layer Out" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="242" srcpinname="Layer" dstnodeid="291" dstpinname="Layer 1">
+   <LINK srcnodeid="82" srcpinname="Y Output Value" dstnodeid="86" dstpinname="Up">
    </LINK>
-   <LINK srcnodeid="289" srcpinname="Layer" dstnodeid="291" dstpinname="Layer 2">
+   <LINK srcnodeid="86" srcpinname="Output" dstnodeid="81" dstpinname="Y Input Value">
    </LINK>
-   <LINK srcnodeid="291" srcpinname="Layer Out" dstnodeid="179" dstpinname="Layer">
+   <LINK srcnodeid="78" srcpinname="Y Output Value" dstnodeid="86" dstpinname="Reset">
    </LINK>
-   <NODE systemname="NOT (Boolean)" nodename="NOT (Boolean)" componentmode="Hidden" id="292">
-   <BOUNDS type="Node" left="3315" top="8040" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="293" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3300" top="7470" width="480" height="480">
-   </BOUNDS>
-   <BOUNDS type="Node" left="3300" top="7470" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Value Type" slicecount="1" values="Boolean">
-   </PIN>
-   <PIN pinname="Behavior" slicecount="1" values="Toggle">
-   </PIN>
-   <PIN pinname="X Input Value" slicecount="1" values="0">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="|Alpha Channel|">
-   </PIN>
-   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="293" srcpinname="Y Output Value" dstnodeid="292" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="292" srcpinname="Output" dstnodeid="289" dstpinname="Enabled">
-   </LINK>
-   <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="295">
-   <BOUNDS type="Node" left="10455" top="11700" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input" visible="1">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="72" srcpinname="Y Output Value" dstnodeid="295" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="139" srcpinname="Y Output Value" dstnodeid="295" dstpinname="Input 2">
-   </LINK>
-   <NODE systemname="Add (Value)" nodename="Add (Value)" componentmode="Hidden" id="296">
-   <BOUNDS type="Node" left="9990" top="12180" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Input 1" visible="1">
-   </PIN>
-   <PIN pinname="Input 2" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="195" srcpinname="Y Output Value" dstnodeid="296" dstpinname="Input 1">
-   </LINK>
-   <LINK srcnodeid="295" srcpinname="Output" dstnodeid="296" dstpinname="Input 2">
-   </LINK>
-   <LINK srcnodeid="296" srcpinname="Output" dstnodeid="288" dstpinname="Input">
-   </LINK>
-   <LINK srcnodeid="120" srcpinname="Y Output Value" dstnodeid="288" dstpinname="Input 2">
-   </LINK>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="297" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="9990" top="13305" width="795" height="240">
-   </BOUNDS>
-   <BOUNDS type="Node" left="9990" top="13305" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Descriptive Name" slicecount="1" values="Time">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="288" srcpinname="Output" dstnodeid="297" dstpinname="Y Input Value">
-   </LINK>
-   <NODE systemname="RGB (Color Join)" nodename="RGB (Color Join)" componentmode="Hidden" id="301">
-   <BOUNDS type="Node" left="3810" top="8835" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Red" visible="1">
-   </PIN>
-   <PIN pinname="Green" visible="1">
-   </PIN>
-   <PIN pinname="Blue" visible="1">
-   </PIN>
-   <PIN pinname="Alpha" visible="1">
-   </PIN>
-   <PIN pinname="Output" visible="1">
-   </PIN>
-   </NODE>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="302" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3810" top="8535" width="795" height="240">
-   </BOUNDS>
-   <BOUNDS type="Node" left="3810" top="8535" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Y Output Value" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="302" srcpinname="Y Output Value" dstnodeid="301" dstpinname="Red">
-   </LINK>
-   <LINK srcnodeid="302" srcpinname="Y Output Value" dstnodeid="301" dstpinname="Green">
-   </LINK>
-   <LINK srcnodeid="302" srcpinname="Y Output Value" dstnodeid="301" dstpinname="Blue">
-   </LINK>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="303" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="3825" top="8220" width="795" height="240">
-   </BOUNDS>
-   <BOUNDS type="Node" left="3825" top="8220" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="303" srcpinname="Y Output Value" dstnodeid="301" dstpinname="Alpha">
-   </LINK>
-   <LINK srcnodeid="301" srcpinname="Output" dstnodeid="289" dstpinname="Color">
-   </LINK>
-   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="304" systemname="IOBox (Value Advanced)">
-   <BOUNDS type="Box" left="2340" top="6720" width="480" height="480">
-   </BOUNDS>
-   <BOUNDS type="Node" left="2340" top="6720" width="0" height="0">
-   </BOUNDS>
-   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
-   </PIN>
-   <PIN pinname="Units" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Precision" slicecount="1" values="4">
-   </PIN>
-   <PIN pinname="Value Type" slicecount="1" values="Boolean">
-   </PIN>
-   <PIN pinname="Behavior" slicecount="1" values="Toggle">
-   </PIN>
-   <PIN pinname="X Input Value" slicecount="1" values="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="304" srcpinname="Y Output Value" dstnodeid="242" dstpinname="Uniform">
+   <LINK srcnodeid="116" srcpinname="Output Enum" dstnodeid="86" dstpinname="Mode">
    </LINK>
    </PATCH>


### PR DESCRIPTION
Dear Mr. Vux,

I've changed the "Texture Input Mode" of the Renderer (DX11 TempTarget) for some modules to the "Inherit". 

This was the issue: 
https://discourse.vvvv.org/t/texture-fx-on-kinect-world/15088/8

Only the DistanceField (DX11.Texture2d) is still untouched because I get the red nodes when I'm opening it with beta33.7.

Hope, everything is right.

Best,
Anton
